### PR TITLE
install backends on macports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,32 +9,34 @@ env:
     - secure: uxYSxs3D3ZOTNjRg0vKk1YsOpG5vWshekMixV4lEuwcSnLJtNHUhZvzoj11GLwqHokTaYXlM1TvFMm7oQBwtW5B+dacnOFar3MJlvu96n+B1CG6ldiIy4uZd+DKR7la0vwK7aTOKyiMK+vWQe8C0kCYBTcN0UiVQn/2nUlFgioM=
 
   matrix:
-    - TEST='macpython27_10.8'
-    - TEST='macpython27_10.8' BIN_NUMPY='1'
-    - TEST='macpython33_10.8'
+#     - TEST='macpython27_10.8'
+#     - TEST='macpython27_10.8' BIN_NUMPY='1'
+#     - TEST='macpython33_10.8'
     # no python 3 numpy installer
     #- TEST='macpython33_10.8' BIN_NUMPY='1'
 
-    - TEST='brew_system'
-    - TEST='brew_system' VENV='1'
+#     - TEST='brew_system'
+#     - TEST='brew_system' VENV='1'
 
-    - TEST='brew_py'
-    - TEST='brew_py' VENV='1'
+#     - TEST='brew_py'
+#     - TEST='brew_py' VENV='1'
 
-    - TEST='brew_py3'
-    - TEST='brew_py3' VENV='1'
+#     - TEST='brew_py3'
+#     - TEST='brew_py3' VENV='1'
 
-    - TEST='macports' PY='2.6'
-    - TEST='macports' PY='2.6' VENV='1'
+#     - TEST='macports' PY='2.6'
+#     - TEST='macports' PY='2.6' VENV='1'
 
-    - TEST='macports_py27'
-    - TEST='macports_py27' VENV='1'
+#     - TEST='macports_py27'
+#     - TEST='macports_py27' VENV='1'
 
-    - TEST='macports' PY='3.2'
-    - TEST='macports' PY='3.2' VENV='1'
+#     - TEST='macports' PY='3.2'
+#     - TEST='macports' PY='3.2' VENV='1'
 
-    - TEST='macports_py33'
-    - TEST='macports_py33' VENV='1'
+#     - TEST='macports_py33'
+#     - TEST='macports_py33' VENV='1'
+
+    - TEST='macports_backends'
 
 install:
   - set -vx  # echo commands

--- a/install.sh
+++ b/install.sh
@@ -329,6 +329,14 @@ elif [ "$TEST" == "macpython33_10.8" ] ; then
 
     install_matplotlib
 
+elif [ "$TEST" == "macports_backends" ] ; then
+
+    install_macports
+    sudo port install -f -v py27-matplotlib +cairo +dvipng +ghostscript +gtk2 +latex +pdftops +pyside + tkinter +webagg
+    export PYTHON=/opt/local/bin/python2.7
+    export PIP="sudo /opt/local/bin/pip-2.7"
+    install_matplotlib
+
 else
     echo "Unknown test setting ($TEST)"
     exit -1

--- a/install.sh
+++ b/install.sh
@@ -339,6 +339,7 @@ elif [ "$TEST" == "macports_backends" ] ; then
     sudo port install -f -v py27-matplotlib +pyside
     export PYTHON=/opt/local/bin/python2.7
     export PIP="sudo /opt/local/bin/pip-2.7"
+    export SUDO="sudo"
     install_matplotlib
 
 else

--- a/install.sh
+++ b/install.sh
@@ -337,6 +337,7 @@ elif [ "$TEST" == "macports_backends" ] ; then
 
     # qt only
     sudo port install -f -v py27-matplotlib +pyside
+    sudo port install inkscape ghostscript
     export PYTHON=/opt/local/bin/python2.7
     export PIP="sudo /opt/local/bin/pip-2.7"
     export SUDO="sudo"

--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,10 @@ elif [ "$TEST" == "macports_backends" ] ; then
 
     install_macports
     # there are tests for pdf, pgf, qt, and svg backends
-    sudo port install -f -v py27-matplotlib +dvipng +ghostscript +latex +pdftops +pyside
+    # sudo port install -f -v py27-matplotlib +dvipng +ghostscript +latex +pdftops +pyside
+
+    # qt only
+    sudo port install -f -v py27-matplotlib +pyside
     export PYTHON=/opt/local/bin/python2.7
     export PIP="sudo /opt/local/bin/pip-2.7"
     install_matplotlib

--- a/install.sh
+++ b/install.sh
@@ -332,7 +332,8 @@ elif [ "$TEST" == "macpython33_10.8" ] ; then
 elif [ "$TEST" == "macports_backends" ] ; then
 
     install_macports
-    sudo port install -f -v py27-matplotlib +cairo +dvipng +ghostscript +gtk2 +latex +pdftops +pyside + tkinter +webagg
+    # there are tests for pdf, pgf, qt, and svg backends
+    sudo port install -f -v py27-matplotlib +dvipng +ghostscript +latex +pdftops +pyside
     export PYTHON=/opt/local/bin/python2.7
     export PIP="sudo /opt/local/bin/pip-2.7"
     install_matplotlib


### PR DESCRIPTION
First attempt at installing a bunch of backends for #4.  Uses macports with all the backend variants enabled.  I'm hoping macports has pre-compiled binaries for these.  Travis will let us know.

This PR should not be merged.  I have disabled all the environments but this new one, since I expect it to take several tries before this builds/tests cleanly.
