### PR TITLE
More comparisions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,8 @@ function install_macports {
     export PATH=$PREFIX/bin:$PATH
     sudo port -v selfupdate
     sudo port install pkgconfig libpng freetype
-    sudo port install inkscape ghostscript
+    # inkscape needs python27, which has to be force installed
+    sudo port -f install inkscape ghostscript  
     require_success "Failed to install matplotlib dependencies"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,7 @@ function install_macports {
     export PATH=$PREFIX/bin:$PATH
     sudo port -v selfupdate
     sudo port install pkgconfig libpng freetype
-    # inkscape needs python27, which has to be force installed
-    sudo port -f install inkscape ghostscript  
+    sudo port install ghostscript  
     require_success "Failed to install matplotlib dependencies"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ function install_macports {
     export PATH=$PREFIX/bin:$PATH
     sudo port -v selfupdate
     sudo port install pkgconfig libpng freetype
+    sudo port install inkscape ghostscript
     require_success "Failed to install matplotlib dependencies"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ if [ "$TEST" == "brew_system" ] ; then
 
     sudo easy_install pip
     brew install freetype libpng pkg-config
-    brew install inkscape ghostscript
+    brew install ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ]; then
@@ -200,7 +200,7 @@ elif [ "$TEST" == "brew_py" ] ; then
     require_success "Failed to install python"
 
     brew install freetype libpng pkg-config
-    brew install inkscape ghostscript
+    brew install ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ] ; then
@@ -225,7 +225,7 @@ elif [ "$TEST" == "brew_py3" ] ; then
     require_success "Failed to install python"
 
     brew install freetype libpng pkg-config
-    brew install inkscape ghostscript
+    brew install ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -172,6 +172,7 @@ if [ "$TEST" == "brew_system" ] ; then
 
     sudo easy_install pip
     brew install freetype libpng pkg-config
+    brew install inkscape ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ]; then
@@ -197,6 +198,7 @@ elif [ "$TEST" == "brew_py" ] ; then
     require_success "Failed to install python"
 
     brew install freetype libpng pkg-config
+    brew install inkscape ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ] ; then
@@ -221,6 +223,7 @@ elif [ "$TEST" == "brew_py3" ] ; then
     require_success "Failed to install python"
 
     brew install freetype libpng pkg-config
+    brew install inkscape ghostscript
     require_success "Failed to install matplotlib dependencies"
 
     if [ -z "$VENV" ] ; then


### PR DESCRIPTION
Install inkscape and ghostscript on macports and homebrew backends.  This might increase the runtime beyond our allocation.  Macports seems to install pre-compiled binaries.  Not sure about brew.
